### PR TITLE
make remove_node return data instead of node

### DIFF
--- a/src/behaviors.rs
+++ b/src/behaviors.rs
@@ -27,8 +27,7 @@ pub enum RemoveBehavior {
     ///
     /// assert!(tree.get(&grandchild_id).is_err());
     /// assert_eq!(tree.get(&root_id).unwrap().children().len(), 0);
-    /// assert_eq!(child.children().len(), 0);
-    /// assert_eq!(child.parent(), None);
+    /// assert_eq!(child, 1);
     /// ```
     ///
     DropChildren,
@@ -55,8 +54,7 @@ pub enum RemoveBehavior {
     ///
     /// assert!(tree.get(&grandchild_id).is_ok());
     /// assert!(tree.get(&root_id).unwrap().children().contains(&grandchild_id));
-    /// assert_eq!(child.children().len(), 0);
-    /// assert_eq!(child.parent(), None);
+    /// assert_eq!(child, 1);
     /// ```
     ///
     LiftChildren,
@@ -81,8 +79,7 @@ pub enum RemoveBehavior {
     ///
     /// assert!(tree.get(&grandchild_id).is_ok());
     /// assert_eq!(tree.get(&root_id).unwrap().children().len(), 0);
-    /// assert_eq!(child.children().len(), 0);
-    /// assert_eq!(child.parent(), None);
+    /// assert_eq!(child, 1);
     /// ```
     ///
     OrphanChildren,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -335,17 +335,7 @@ impl<T> Tree<T> {
     /// Remove a `Node` from the `Tree`.  The `RemoveBehavior` provided determines what happens to
     /// the removed `Node`'s children.
     ///
-    /// Returns a `Result` containing the removed `Node` or a `NodeIdError` if one occurred.
-    ///
-    /// **NOTE:** The `Node` that is returned will have its parent and child values cleared to avoid
-    /// providing the caller with extra copies of `NodeId`s should the corresponding `Node`s be
-    /// removed from the `Tree` at a later time.
-    ///
-    /// If the caller needs a copy of the parent or child `NodeId`s, they must `Clone` them before
-    /// this `Node` is removed from the `Tree`.  Please see the
-    /// [Potential `NodeId` Issues](struct.NodeId.html#potential-nodeid-issues) section
-    /// of the `NodeId` documentation for more information on the implications of calling `Clone` on
-    /// a `NodeId`.
+    /// Returns a `Result` containing the removed `Node` data or a `NodeIdError` if one occurred.
     ///
     /// ```
     /// use id_tree::*;
@@ -360,17 +350,16 @@ impl<T> Tree<T> {
     ///
     /// let child = tree.remove_node(child_id, DropChildren).unwrap();
     ///
+    /// # assert_eq!(child, 1);
     /// # assert!(tree.get(&grandchild_id).is_err());
     /// # assert_eq!(tree.get(&root_id).unwrap().children().len(), 0);
-    /// # assert_eq!(child.children().len(), 0);
-    /// # assert_eq!(child.parent(), None);
     /// ```
     ///
     pub fn remove_node(
         &mut self,
         node_id: NodeId,
         behavior: RemoveBehavior,
-    ) -> Result<Node<T>, NodeIdError> {
+    ) -> Result<T, NodeIdError> {
         let (is_valid, error) = self.is_valid_node_id(&node_id);
         if !is_valid {
             return Err(error.expect(
@@ -384,6 +373,7 @@ impl<T> Tree<T> {
             RemoveBehavior::LiftChildren => self.remove_node_lift_children(node_id),
             RemoveBehavior::OrphanChildren => self.remove_node_orphan_children(node_id),
         }
+        .map(|node| node.data)
     }
 
     ///
@@ -1831,9 +1821,7 @@ mod tree_tests {
 
         assert_eq!(Some(&root_id), tree.root_node_id());
 
-        assert_eq!(node_1.data(), &1);
-        assert_eq!(node_1.children().len(), 0);
-        assert!(node_1.parent().is_none());
+        assert_eq!(node_1, 1);
         assert!(tree.get(&node_1_id).is_err());
 
         let root_ref = tree.get(&root_id).unwrap();
@@ -1867,9 +1855,7 @@ mod tree_tests {
 
         assert_eq!(Some(&root_id), tree.root_node_id());
 
-        assert_eq!(node_1.data(), &1);
-        assert_eq!(node_1.children().len(), 0);
-        assert!(node_1.parent().is_none());
+        assert_eq!(node_1, 1);
         assert!(tree.get(&node_1_id).is_err());
 
         let node_2_ref = tree.get(&node_2_id).unwrap();


### PR DESCRIPTION
This changes remove_node to return a T value instead of a Node<T>.