### PR TITLE
add serialization support for Trees

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub use tree::TreeBuilder;
 /// sort out because an explicit `Clone` is required for such an error to occur.
 ///
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Serialize))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct NodeId {
     tree_id: ProcessUniqueId,
     index: usize,

--- a/src/node.rs
+++ b/src/node.rs
@@ -76,6 +76,7 @@ impl<T> NodeBuilder<T> {
 /// A container that wraps data in a given `Tree`.
 ///
 #[derive(Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Node<T> {
     pub(crate) data: T,
     pub(crate) parent: Option<NodeId>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -154,6 +154,7 @@ impl<T> TreeBuilder<T> {
 /// library, but they can happen due to bugs.
 ///
 #[derive(Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Tree<T> {
     id: ProcessUniqueId,
     root: Option<NodeId>,


### PR DESCRIPTION
Finishing up #79 by deriving `Serialize` and `Deserialize` for `Node`, `NodeId` and `Tree`.

This is what I expected behind the `serde_support` feature.