### PR TITLE
bump version to 1.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_tree"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Ian Burns <iwburns8@gmail.com>"]
 description = "A library for creating and modifying Tree structures."
 documentation = "https://docs.rs/id_tree"


### PR DESCRIPTION
This change also runs rustfmt across the library, removes usages of
the try!() macro, tweaks a doc-test to include assertions, and adds a
bit of extra info to some doc comments.